### PR TITLE
Autofill url

### DIFF
--- a/webapp/src/ux/components/App.jsx
+++ b/webapp/src/ux/components/App.jsx
@@ -67,7 +67,11 @@ class App extends React.Component {
         window.BACKGROUND_INTERFACE.call(message, (result) => {
             if (!result) {
                 result = 'splash';
+            } else if (this.state.account) {
+                result = 'landing'
+                console.log('landing')
             }
+            console.log(result)
             self.setState({tab:result}, () => {
                 self._mountedTab = true ;
                 self._mounted = self._mountedTab && self._mountedAccount && self._mountedAction;
@@ -84,7 +88,11 @@ class App extends React.Component {
         window.BACKGROUND_INTERFACE.call(message, (result) => {
             if (!result) {
                 result = null;
+            } else if (this.state.account) {
+                result = 'like'
+                console.log('like')
             }
+            console.log(result)
             self.setState({action:result}, () => {
                 self._mountedAction = true ;
                 self._mounted = self._mountedTab && self._mountedAccount && self._mountedAction;

--- a/webapp/src/ux/components/App.jsx
+++ b/webapp/src/ux/components/App.jsx
@@ -69,9 +69,7 @@ class App extends React.Component {
                 result = 'splash';
             } else if (this.state.account) {
                 result = 'landing'
-                console.log('landing')
             }
-            console.log(result)
             self.setState({tab:result}, () => {
                 self._mountedTab = true ;
                 self._mounted = self._mountedTab && self._mountedAccount && self._mountedAction;
@@ -90,9 +88,7 @@ class App extends React.Component {
                 result = null;
             } else if (this.state.account) {
                 result = 'like'
-                console.log('like')
             }
-            console.log(result)
             self.setState({action:result}, () => {
                 self._mountedAction = true ;
                 self._mounted = self._mountedTab && self._mountedAccount && self._mountedAction;

--- a/webapp/src/ux/components/Header.jsx
+++ b/webapp/src/ux/components/Header.jsx
@@ -15,6 +15,7 @@ class Header extends React.Component {
     navigateHome() {
         if (this.context.account) {
             this.context.navigate('landing')
+            this.context.navigateAction('like')
         } else {
             this.context.navigate('splash')
         }

--- a/webapp/src/ux/components/LandingContent.jsx
+++ b/webapp/src/ux/components/LandingContent.jsx
@@ -30,7 +30,6 @@ class LandingContent extends React.Component {
   }
   
   render = () => {
-    console.log(this.context.action)
 
     let translateMap = {
       'like': {

--- a/webapp/src/ux/components/LandingContent.jsx
+++ b/webapp/src/ux/components/LandingContent.jsx
@@ -28,8 +28,9 @@ class LandingContent extends React.Component {
   pages = {
     like: {title:"Like a web page", component:<Like />}
   }
-
+  
   render = () => {
+    console.log(this.context.action)
 
     let translateMap = {
       'like': {

--- a/webapp/src/ux/components/like/AuthorBadge.jsx
+++ b/webapp/src/ux/components/like/AuthorBadge.jsx
@@ -11,15 +11,9 @@ class AuthorBadge extends React.Component {
     static contextType = AppContext;
 
     render = () => {
-        var url = this.props.url
-        var urlList = url.split('//')
-        if (urlList.length >= 2){
-            url = urlList[1].split('.')[0]
-        }
         return (
             <AuthorContainer>
                 <img src={GreenCheck} alt='green checks'/>
-                <div>{url}</div>
                 <LikeBadge>{this.props.nLikes} likes</LikeBadge>
                 <Identicon size={30} value={'5GWEiv2fSRoeaXwhTCP1qvnJRT8BVnXnTL8CVsnP8M3G7z2i'}/>
             </AuthorContainer>
@@ -37,7 +31,7 @@ const AuthorContainer = styled.div`
     border-radius: 15px;
     align-items: center;
     justify-content: space-around;
-    width: 220px;
+    width: 180px;
 `
 const LikeBadge = styled.div`
     margin: 5px;

--- a/webapp/src/ux/components/like/Like.jsx
+++ b/webapp/src/ux/components/like/Like.jsx
@@ -121,8 +121,8 @@ class Like extends React.Component {
     }
 
     renderUrlInput = () => {
+        let inputProps = {endAdornment: this.renderInputAdornment()} ;
         if (this.state.env === 'app'){
-            let inputProps = {endAdornment: this.renderInputAdornment()} ;
             return (<TextField
                         id="lookup-url-input"
                         label="Lookup URL status"
@@ -139,10 +139,14 @@ class Like extends React.Component {
                     self.setState({url: activeTab}, () => {self.lookupUrl()});
                 }
             });
-            // if (this.state.lookedUp === false) {
-            //     this.clearUrl();
-            // }
-            return 
+            return (<TextField
+                id="lookup-url-input"
+                label="Lookup URL status"
+                variant="outlined"
+                fullWidth={true}
+                value={this.state.url}
+                onChange={this.handleUrlChange}
+                InputProps={inputProps} />) ;
         }
     }
 
@@ -187,7 +191,7 @@ class Like extends React.Component {
         return (
             <LikeContainer>
                 <Title>
-                    Like Current Page
+                    Like Selected Page
                 </Title>
                 <UrlInput>
                     {this.renderUrlInput()}

--- a/webapp/src/ux/components/like/Like.jsx
+++ b/webapp/src/ux/components/like/Like.jsx
@@ -21,7 +21,8 @@ class Like extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            lookedUp:false,
+            lookedUp: false,
+            cleared: false,
             url: "",
             referrer: null,
             likePrice: null,
@@ -64,6 +65,7 @@ class Like extends React.Component {
         this.unsubscribe() ;
         this.setState({
             lookedUp:false,
+            cleared: true,
             url:"",
             likesSubmittedCount:null,
         }) ;
@@ -135,7 +137,7 @@ class Like extends React.Component {
             var self = this
             window.chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
                 var activeTab = tabs[0].url;
-                if (self.state.lookedUp === false) {
+                if (self.state.lookedUp === false && self.state.cleared === false) {
                     self.setState({url: activeTab}, () => {self.lookupUrl()});
                 }
             });


### PR DESCRIPTION
I went with a different approach. Instead of two different pages "current" and "any", I made one page called "Like Selected Page". It auto fills the url of the active tab in the extension. The user can still clear and enter a different url if they wish. 
I also set it so that it always opens to the "like" page once they have added an account.
@randombishop 